### PR TITLE
Remove startup errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY ./ /go/src/github.com/appcelerator/docker-haproxy
 RUN echo "@edge http://nl.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories && \
     echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories && \
     echo "@community http://nl.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
-RUN apk update && \
+RUN apk update && apk upgrade && \
     apk -v --virtual build-deps add git make bash go@community musl-dev && \
     apk -v add curl go@community && \
     go version && \

--- a/haproxy.cfg.tpt
+++ b/haproxy.cfg.tpt
@@ -12,8 +12,8 @@ resolvers docker
 
 defaults
     mode http
-    log global
-    option httplog
+    option dontlog-normal
+    option dontlognull
     timeout connect 5000ms
     timeout client 50000ms
     timeout server 50000ms


### PR DESCRIPTION
- Image was not building anymore because of conflicts in package versions
- Fixes config errors:

> launching HAProxy on initial configuration
> [WARNING] 297/113826 (14) : config : log format ignored for frontend 'monitoring' since it has no log address.
> [WARNING] 297/113826 (14) : config : log format ignored for frontend 'main_http-in' since it has no log address.
> [WARNING] 297/113826 (14) : config : log format ignored for frontend 'main_registry' since it has no log address.
> [WARNING] 297/113826 (14) : parsing [/usr/local/etc/haproxy/haproxy.cfg:16] : 'option httplog' not usable with frontend 'main_grpc' (needs 'mode http'). Falling back to 'option tc
> plog'.
> [WARNING] 297/113826 (14) : config : log format ignored for frontend 'main_grpc' since it has no log address.
